### PR TITLE
Increased timeout in example screenshot integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ jobs:
       - sdkmanager "system-images;android-$EMULATOR_API_LEVEL;$ABI" > /dev/null
       - sdkmanager --list | head -15
       - echo no | avdmanager create avd -n Nexus_6P -k "system-images;android-$EMULATOR_API_LEVEL;$ABI"
+      - echo "hw.lcd.width=1440" >> /home/travis/.android/avd/Nexus_6P.avd/config.ini
+      - echo "hw.lcd.height=2560" >> /home/travis/.android/avd/Nexus_6P.avd/config.ini
       # fix timezone warning on osx
       - sudo ln -sf /usr/share/zoneinfo/US/Pacific /etc/localtime
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ jobs:
       - sdkmanager --list | head -15
       - echo no | avdmanager create avd -n Nexus_6P -k "system-images;android-$EMULATOR_API_LEVEL;$ABI"
 #      - cat ~/.android/avd/Nexus_6P.avd/config.ini
-#      - echo "hw.lcd.width=1440" >> ~/.android/avd/Nexus_6P.avd/config.ini
-#      - echo "hw.lcd.height=2560" >> ~/.android/avd/Nexus_6P.avd/config.ini
+      - echo "hw.lcd.width=1440" >> ~/.android/avd/Nexus_6P.avd/config.ini
+      - echo "hw.lcd.height=2560" >> ~/.android/avd/Nexus_6P.avd/config.ini
       # fix timezone warning on osx
       - sudo ln -sf /usr/share/zoneinfo/US/Pacific /etc/localtime
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ jobs:
       - sdkmanager "system-images;android-$EMULATOR_API_LEVEL;$ABI" > /dev/null
       - sdkmanager --list | head -15
       - echo no | avdmanager create avd -n Nexus_6P -k "system-images;android-$EMULATOR_API_LEVEL;$ABI"
+      - find ~/.android/avd
+      - mkdir -p ~/.android/avd/Nexus_6P.avd
       - echo "hw.lcd.width=1440" >> /home/travis/.android/avd/Nexus_6P.avd/config.ini
       - echo "hw.lcd.height=2560" >> /home/travis/.android/avd/Nexus_6P.avd/config.ini
       # fix timezone warning on osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ jobs:
       - sdkmanager "system-images;android-$EMULATOR_API_LEVEL;$ABI" > /dev/null
       - sdkmanager --list | head -15
       - echo no | avdmanager create avd -n Nexus_6P -k "system-images;android-$EMULATOR_API_LEVEL;$ABI"
-      - cat ~/.android/avd/Nexus_6P.avd/config.ini
-      - echo "hw.lcd.width=1440" >> ~/.android/avd/Nexus_6P.avd/config.ini
-      - echo "hw.lcd.height=2560" >> ~/.android/avd/Nexus_6P.avd/config.ini
+#      - cat ~/.android/avd/Nexus_6P.avd/config.ini
+#      - echo "hw.lcd.width=1440" >> ~/.android/avd/Nexus_6P.avd/config.ini
+#      - echo "hw.lcd.height=2560" >> ~/.android/avd/Nexus_6P.avd/config.ini
       # fix timezone warning on osx
       - sudo ln -sf /usr/share/zoneinfo/US/Pacific /etc/localtime
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,9 @@ jobs:
       - sdkmanager "system-images;android-$EMULATOR_API_LEVEL;$ABI" > /dev/null
       - sdkmanager --list | head -15
       - echo no | avdmanager create avd -n Nexus_6P -k "system-images;android-$EMULATOR_API_LEVEL;$ABI"
-      - find ~/.android/avd
-      - mkdir -p ~/.android/avd/Nexus_6P.avd
-      - echo "hw.lcd.width=1440" >> /home/travis/.android/avd/Nexus_6P.avd/config.ini
-      - echo "hw.lcd.height=2560" >> /home/travis/.android/avd/Nexus_6P.avd/config.ini
+      - cat ~/.android/avd/Nexus_6P.avd/config.ini
+      - echo "hw.lcd.width=1440" >> ~/.android/avd/Nexus_6P.avd/config.ini
+      - echo "hw.lcd.height=2560" >> ~/.android/avd/Nexus_6P.avd/config.ini
       # fix timezone warning on osx
       - sudo ln -sf /usr/share/zoneinfo/US/Pacific /etc/localtime
 

--- a/example/test_driver/main_test.dart
+++ b/example/test_driver/main_test.dart
@@ -44,6 +44,6 @@ void main() {
 
       // increase timeout from 30 seconds for testing
       // on slow running emulators in cloud
-    }, timeout: Timeout(Duration(seconds: 60)));
+    }, timeout: Timeout(Duration(seconds: 120)));
   });
 }

--- a/example/test_driver/main_test.dart
+++ b/example/test_driver/main_test.dart
@@ -10,10 +10,6 @@ import 'package:screenshots/config.dart';
 import 'package:screenshots/capture_screen.dart';
 
 void main() {
-  // used for running tests in cloud
-  // (may not be necessary if running locally)
-  final timeout = Duration(seconds: 60);
-
   group('end-to-end test', () {
     FlutterDriver driver;
     final Map config = Config().config;
@@ -32,19 +28,22 @@ void main() {
       SerializableFinder fab = find.byTooltip('Increment');
 
       // Wait for the floating action button to appear
-      await driver.waitFor(fab, timeout: timeout);
+      await driver.waitFor(fab);
 
       // take screenshot before number is incremented
-      await screenshot(driver, config, '0', timeout);
+      await screenshot(driver, config, '0');
 
       // Tap on the fab
-      await driver.tap(fab, timeout: timeout);
+      await driver.tap(fab);
 
       // Wait for text to change to the desired value
-      await driver.waitFor(find.text('1'), timeout: timeout);
+      await driver.waitFor(find.text('1'));
 
       // take screenshot after number is incremented
-      await screenshot(driver, config, '1', timeout);
-    });
+      await screenshot(driver, config, '1');
+
+      // increase timeout from 30 seconds for testing
+      // on slow running emulators in cloud
+    }, timeout: Timeout(Duration(seconds: 60)));
   });
 }

--- a/example/test_driver/main_test.dart
+++ b/example/test_driver/main_test.dart
@@ -10,6 +10,10 @@ import 'package:screenshots/config.dart';
 import 'package:screenshots/capture_screen.dart';
 
 void main() {
+  // used for running tests in cloud
+  // (may not be necessary if running locally)
+  final timeout = Duration(seconds: 60);
+
   group('end-to-end test', () {
     FlutterDriver driver;
     final Map config = Config().config;
@@ -28,19 +32,19 @@ void main() {
       SerializableFinder fab = find.byTooltip('Increment');
 
       // Wait for the floating action button to appear
-      await driver.waitFor(fab);
+      await driver.waitFor(fab, timeout: timeout);
 
       // take screenshot before number is incremented
-      await screenshot(driver, config, '0');
+      await screenshot(driver, config, '0', timeout);
 
       // Tap on the fab
-      await driver.tap(fab);
+      await driver.tap(fab, timeout: timeout);
 
       // Wait for text to change to the desired value
-      await driver.waitFor(find.text('1'));
+      await driver.waitFor(find.text('1'), timeout: timeout);
 
       // take screenshot after number is incremented
-      await screenshot(driver, config, '1');
+      await screenshot(driver, config, '1', timeout);
     });
   });
 }

--- a/example/test_driver/main_test.dart
+++ b/example/test_driver/main_test.dart
@@ -10,10 +10,6 @@ import 'package:screenshots/config.dart';
 import 'package:screenshots/capture_screen.dart';
 
 void main() {
-  // used for running tests in cloud
-  // (may not be necessary if running locally)
-  final timeout = Duration(seconds: 20);
-
   group('end-to-end test', () {
     FlutterDriver driver;
     final Map config = Config().config;
@@ -32,19 +28,19 @@ void main() {
       SerializableFinder fab = find.byTooltip('Increment');
 
       // Wait for the floating action button to appear
-      await driver.waitFor(fab, timeout: timeout);
+      await driver.waitFor(fab);
 
       // take screenshot before number is incremented
-      await screenshot(driver, config, '0', timeout);
+      await screenshot(driver, config, '0');
 
       // Tap on the fab
-      await driver.tap(fab, timeout: timeout);
+      await driver.tap(fab);
 
       // Wait for text to change to the desired value
-      await driver.waitFor(find.text('1'), timeout: timeout);
+      await driver.waitFor(find.text('1'));
 
       // take screenshot after number is incremented
-      await screenshot(driver, config, '1', timeout);
+      await screenshot(driver, config, '1');
     });
   });
 }

--- a/lib/capture_screen.dart
+++ b/lib/capture_screen.dart
@@ -4,10 +4,11 @@ import 'dart:io';
 ///
 /// Called by integration test to capture images.
 ///
-Future screenshot(final driver, Map config, String name) async {
+Future screenshot(final driver, Map config, String name,
+    [Duration timeout = const Duration(seconds: 5)]) async {
   // todo: auto-naming scheme
   final stagingDir = config['staging'] + '/test';
-  await driver.waitUntilNoTransientCallbacks();
+  await driver.waitUntilNoTransientCallbacks(timeout: timeout);
   final List<int> pixels = await driver.screenshot();
   final File file =
       await File(stagingDir + '/' + name + '.png').create(recursive: true);

--- a/lib/capture_screen.dart
+++ b/lib/capture_screen.dart
@@ -4,11 +4,10 @@ import 'dart:io';
 ///
 /// Called by integration test to capture images.
 ///
-Future screenshot(final driver, Map config, String name,
-    [Duration timeout = const Duration(seconds: 5)]) async {
+Future screenshot(final driver, Map config, String name) async {
   // todo: auto-naming scheme
   final stagingDir = config['staging'] + '/test';
-  await driver.waitUntilNoTransientCallbacks(timeout: timeout);
+  await driver.waitUntilNoTransientCallbacks();
   final List<int> pixels = await driver.screenshot();
   final File file =
       await File(stagingDir + '/' + name + '.png').create(recursive: true);

--- a/lib/capture_screen.dart
+++ b/lib/capture_screen.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 /// Called by integration test to capture images.
 ///
 Future screenshot(final driver, Map config, String name,
-    [Duration timeout = const Duration(seconds: 5)]) async {
+    [Duration timeout = const Duration(seconds: 30)]) async {
   // todo: auto-naming scheme
   final stagingDir = config['staging'] + '/test';
   await driver.waitUntilNoTransientCallbacks(timeout: timeout);


### PR DESCRIPTION
The default timeout for a test is 30 seconds. When running in the cloud on a (slow running) emulator more time is needed. So increased timeout of test from 30 seconds to 120 seconds (to be on the safe side).

Also removed all timeouts from integration test. Flutter attempts to provide several warnings instead (and not timing out). This seems to be working well for (slow running) emulators in the cloud.