### PR TITLE
Add waitUntilNoTransientCallbacks option

### DIFF
--- a/lib/src/capture_screen.dart
+++ b/lib/src/capture_screen.dart
@@ -7,10 +7,14 @@ import 'globals.dart';
 /// Called by integration test to capture images.
 Future screenshot(final driver, Config config, String name,
     {Duration timeout = const Duration(seconds: 30),
-    bool silent = false}) async {
+    bool silent = false,
+    bool waitUntilNoTransientCallbacks = true}) async {
   if (config.isScreenShotsAvailable) {
     // todo: auto-naming scheme
-    await driver.waitUntilNoTransientCallbacks(timeout: timeout);
+    if (waitUntilNoTransientCallbacks) {
+      await driver.waitUntilNoTransientCallbacks(timeout: timeout);
+    }
+
     final pixels = await driver.screenshot();
     final testDir = '${config.stagingDir}/$kTestScreenshotsDir';
     final file =


### PR DESCRIPTION
In some apps this will always timeout.
This change gives the option of disabling it.