### PR TITLE
Fixed bug with finding running device

### DIFF
--- a/lib/src/daemon_client.dart
+++ b/lib/src/daemon_client.dart
@@ -72,6 +72,7 @@ class DaemonClient {
     await _sendCommand(command);
 
     // wait for expected device-added-emulator event
+    // Note: future does not complete if emulator already running
     final results = await Future.wait(
         <Future>[_waitForResponse.future, _waitForEvent.future]);
     // process the response
@@ -260,8 +261,12 @@ abstract class BaseDevice {
 
 /// Describe an emulator.
 class DaemonEmulator extends BaseDevice {
-  DaemonEmulator(String id, String name, String category, String platformType)
-      : super(id, name, category, platformType);
+  DaemonEmulator(
+    String id,
+    String name,
+    String category,
+    String platformType,
+  ) : super(id, name, category, platformType);
 }
 
 /// Describe a device.
@@ -269,27 +274,38 @@ class DaemonDevice extends BaseDevice {
   final String platform;
   final bool emulator;
   final bool ephemeral;
+  final String emulatorId;
   final String iosModel; //  iOS model
-  DaemonDevice(String id, String name, String category, String platformType,
-      this.platform, this.emulator, this.ephemeral,
-      {this.iosModel})
-      : super(id, name, category, platformType);
+  DaemonDevice(
+    String id,
+    String name,
+    String category,
+    String platformType,
+    this.platform,
+    this.emulator,
+    this.ephemeral,
+    this.emulatorId, {
+    this.iosModel,
+  }) : super(id, name, category, platformType);
 
   @override
   String toString() {
     return super.toString() +
-        ' platform: $platform, emulator: $emulator, ephemeral: $ephemeral, iosModel: $iosModel';
+        ' platform: $platform, emulator: $emulator, ephemeral: $ephemeral, emulatorId: $emulatorId, iosModel: $iosModel';
   }
 }
 
 DaemonEmulator loadDaemonEmulator(emulator) {
-  final flutterEmulator = DaemonEmulator(emulator['id'], emulator['name'],
-      emulator['category'], emulator['platformType']);
-  return flutterEmulator;
+  return DaemonEmulator(
+    emulator['id'],
+    emulator['name'],
+    emulator['category'],
+    emulator['platformType'],
+  );
 }
 
 DaemonDevice loadDaemonDevice(device) {
-  final flutterDevice = DaemonDevice(
+  return DaemonDevice(
       device['id'],
       device['name'],
       device['category'],
@@ -297,6 +313,6 @@ DaemonDevice loadDaemonDevice(device) {
       device['platform'],
       device['emulator'],
       device['ephemeral'],
+      device['emulatorId'],
       iosModel: device['model']);
-  return flutterDevice;
 }

--- a/test/run_test.dart
+++ b/test/run_test.dart
@@ -76,7 +76,8 @@ main() {
         'emulator': true,
         'category': 'mobile',
         'platformType': 'android',
-        'ephemeral': true
+        'ephemeral': true,
+        'emulatorId': 'Nexus_6P_API_28',
       });
 
       setUp(() {
@@ -102,8 +103,6 @@ main() {
         // fake process responses
         final List<Call> calls = [
           ...unpackScriptsCalls,
-          Call('$adbPath -s emulator-5554 emu avd name',
-              ProcessResult(0, 0, 'Nexus_6P_API_28', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',
               ProcessResult(0, 0, 'en-US', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',
@@ -148,8 +147,6 @@ main() {
         // fake process responses
         final List<Call> calls = [
           ...unpackScriptsCalls,
-          Call('$adbPath -s emulator-5554 emu avd name',
-              ProcessResult(0, 0, 'Nexus_6P_API_28', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',
               ProcessResult(0, 0, 'en-US', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',

--- a/test/run_test.dart
+++ b/test/run_test.dart
@@ -103,6 +103,8 @@ main() {
         // fake process responses
         final List<Call> calls = [
           ...unpackScriptsCalls,
+          Call('$adbPath -s emulator-5554 emu avd name',
+              ProcessResult(0, 0, 'Nexus_6P_API_28', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',
               ProcessResult(0, 0, 'en-US', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',
@@ -147,6 +149,8 @@ main() {
         // fake process responses
         final List<Call> calls = [
           ...unpackScriptsCalls,
+          Call('$adbPath -s emulator-5554 emu avd name',
+              ProcessResult(0, 0, 'Nexus_6P_API_28', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',
               ProcessResult(0, 0, 'en-US', '')),
           Call('$adbPath -s emulator-5554 shell getprop persist.sys.locale',

--- a/test/screenshots_test.dart
+++ b/test/screenshots_test.dart
@@ -889,10 +889,31 @@ void main() {
           loadDaemonDevice(androidDevice),
           loadDaemonDevice(iosDevice)
         ];
-        DaemonDevice deviceInfo =
-            run.findRunningDevice(runningDevices, androidDeviceName);
+        final installedEmulators = [
+          loadDaemonEmulator({
+            'id': 'Nexus_6P_API_28',
+            'name': 'Nexus 6P',
+            'category': 'mobile',
+            'platformType': 'android'
+          }),
+          loadDaemonEmulator({
+            'id': 'Nexus_6P_API_30',
+            'name': 'Nexus 6P',
+            'category': 'mobile',
+            'platformType': 'android'
+          }),
+          loadDaemonEmulator({
+            'id': 'apple_ios_simulator',
+            'name': 'iOS Simulator',
+            'category': 'mobile',
+            'platformType': 'ios'
+          })
+        ];
+        DaemonDevice deviceInfo = run.findRunningDevice(
+            runningDevices, installedEmulators, androidDeviceName);
         expect(deviceInfo, androidDevice);
-        deviceInfo = run.findRunningDevice(runningDevices, iosDeviceName);
+        deviceInfo = run.findRunningDevice(
+            runningDevices, installedEmulators, iosDeviceName);
         expect(deviceInfo, iosDevice);
       }, skip: utils.isCI());
     });

--- a/test/screenshots_test.dart
+++ b/test/screenshots_test.dart
@@ -889,31 +889,10 @@ void main() {
           loadDaemonDevice(androidDevice),
           loadDaemonDevice(iosDevice)
         ];
-        final installedEmulators = [
-          {
-            'id': 'Nexus_6P_API_28',
-            'name': 'Nexus 6P',
-            'category': 'mobile',
-            'platformType': 'android'
-          },
-          {
-            'id': 'Nexus_6P_API_30',
-            'name': 'Nexus 6P',
-            'category': 'mobile',
-            'platformType': 'android'
-          },
-          {
-            'id': 'apple_ios_simulator',
-            'name': 'iOS Simulator',
-            'category': 'mobile',
-            'platformType': 'ios'
-          }
-        ];
-        DaemonDevice deviceInfo = run.findRunningDevice(
-            runningDevices, installedEmulators, androidDeviceName);
+        DaemonDevice deviceInfo =
+            run.findRunningDevice(runningDevices, androidDeviceName);
         expect(deviceInfo, androidDevice);
-        deviceInfo = run.findRunningDevice(
-            runningDevices, installedEmulators, iosDeviceName);
+        deviceInfo = run.findRunningDevice(runningDevices, iosDeviceName);
         expect(deviceInfo, iosDevice);
       }, skip: utils.isCI());
     });


### PR DESCRIPTION
Used newly present 'emulator_id' to identify a running emulator.

fixes #141 