### PR TITLE
Released v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0
+- Added support for non-default config file in test #128
+- Added check for flutter path at startup #136
+- Added option to by-pass waitUntilNoTransientCallbacks when taking screenshot #138 #139
+- Fixed bug with finding real android devices #141
+- Added support for skipping builds #142
+
 ## 2.0.2+1
 - Reduced description length to below 180 chars  
 A pub.dev issue

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: screenshots
 description: Auto-generation of screenshots for Apple and Play Stores using emulators, simulators and real devices. Includes support for multiple locales and framing. Compatible with fastlane.
-version: 2.0.2+1
+version: 2.1.0
 homepage: https://github.com/mmcc007/screenshots
 author: Maurice McCabe <mmcc007@gmail.com>
 


### PR DESCRIPTION
Released v2.1.0
- Added support for non-default config file in test #128
- Added check for flutter path at startup #136
- Added option to by-pass waitUntilNoTransientCallbacks when taking screenshot #138 #139
- Fixed bug with finding real android devices #141
- Added support for skipping builds #142