### PR TITLE
Run test on a device in multiple orientations in a single run.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,5 +29,6 @@ integration_task:
     - export PATH="$HOME/.pub-cache/bin:$PATH" # needed to find screenshots
     - cd example
     - screenshots -c screenshots_ios.yaml -v
+  find_artifacts: find ios/fastlane/screenshots
   screenshot_artifacts:
-    path: ios/fastlane/screenshots/*
+    path: ios/fastlane/screenshots

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ For introduction to _Screenshots_ see https://medium.com/@nocnoc/automated-scree
 
 _Screenshots_ is a standalone command line utility and package for capturing screenshot images for Flutter.   
 
-_Screenshots_ will start the required android emulators and iOS simulators (or find attached devices), run your screen capture tests on each emulator/simulator (or device), process the images, and drop them off to Fastlane for delivery to both stores.
+_Screenshots_ will start the required android emulators and iOS simulators (or find attached devices), run tests, process the captured screenshots, and drop them off to Fastlane for delivery to both stores.
 
-It is inspired by three tools from Fastlane:  
+_Screenshots_ is inspired by three tools from Fastlane:  
 1. [Snapshots](https://docs.fastlane.tools/getting-started/ios/screenshots/)  
 This is used to capture screenshots on iOS using iOS UI Tests.
 1. [Screengrab](https://docs.fastlane.tools/actions/screengrab/)  
@@ -40,15 +40,15 @@ Since all three of these Fastlane tools do not work with Flutter, _Screenshots_ 
 Since Flutter integration testing is designed to work transparently across iOS and Android, capturing images using _Screenshots_ is easy.
 
 Features include: 
-1. Works with your existing tests  
+1. Works with existing tests  
 Add a single line for each screenshot.
-1. Run your tests on any device  
-Select the devices you want to run on, using a convenient config file. _Screenshots_ will find the devices (real or emulated) and run your tests.
+1. Run tests on any device  
+Select the devices to run on using a convenient config file. _Screenshots_ will find the devices (real or emulated) and run tests.
 1. One run for both platforms  
-_Screenshots_ runs your tests on both iOS and Android in one run.  
+_Screenshots_ runs tests on both iOS and Android in one run.  
 (as opposed to making separate Snapshots and Screengrab runs)
 1. One run for multiple locales  
-If your app supports multiple locales, _Screenshots_ will optionally set the locales listed in the config file before running each test.
+If app supports multiple locales, _Screenshots_ will optionally set the locales listed in the config file before running each test.
 1. One run for frames  
 Optionally places images in device frames in same run.  
 (as opposed to making separate FrameIt runs... which supports iOS only)
@@ -141,17 +141,18 @@ sample usage: screenshots
 -h, --help                                          Display this help information.
 ```
 
-# Modifying your tests for _Screenshots_
-A special function is provided in the _Screenshots_ package that is called by the test each time you want to capture a screenshot. 
+# Modifying tests for _Screenshots_
+A special function is provided in the _Screenshots_ package that is called by the test to capture a screenshot. 
 _Screenshots_ will then process the images appropriately during a _Screenshots_ run.
 
-To capture screenshots in your tests:
-1. Include the _Screenshots_ package in your pubspec.yaml's dev_dependencies section  
+To capture screenshots in tests:
+1. Add _Screenshots_ package in app's pubspec.yaml's dev_dependencies section  
    ````yaml
+   dev_dependencies:
      screenshots: ^<current version>
    ````
-2. In your tests
-    1. Import the dependencies  
+2. In tests
+    1. Import the dependency  
        ````dart
        import 'package:screenshots/screenshots.dart';
        ````
@@ -164,15 +165,15 @@ To capture screenshots in your tests:
            await screenshot(driver, config, 'myscreenshot1');
        ````
        
-Note: make sure your screenshot names are unique across all your tests.
+Note: make sure screenshot names are unique across all tests.
 
-Note: to turn off the debug banner on your screens, in your integration test's main(), call:
+Note: to turn off the debug banner, in the integration test's main(), call:
 ````dart
   WidgetsApp.debugAllowBannerOverride = false; // remove debug banner for screenshots
 ````
 
 ## Modifying tests based on screenshots environment
-In some cases it is useful to know what device, device type, screen size, screen orientation and locale you are currently testing with. To obtain this information in your test use:
+In some cases it is useful to know what device, device type, screen size, screen orientation and locale the test is currently running with. To obtain this information use:
 ```
 final screenshotsEnv = config.screenshotsEnv;
 ```
@@ -224,8 +225,16 @@ _frame_ parameter notes:
 - set to true for devices unknown to _screenshots_.
 
 _orientation_ parameter notes:
+- multiple orientations can be specified. For example:
+    ```yaml
+        iPhone XS Max:
+          orientation:
+            - Portrait
+            - LandscapeRight
+    ```
+- landscape orientation disables framing  
+  This is because status/navigation bars in landscape mode are currently not implemented.
 - orientation on iOS simulators is implemented using an AppleScript script which requires granting permission on first use.
-
 
 ## Test Options
 In addition to using the default flutter driver mode, tests can also be specified using flutter driver parameters. For example:
@@ -239,11 +248,11 @@ tests:
 _Screenshots_ can be used to monitor any unexpected changes to the UI by comparing the new screenshots to previously recorded screenshots. Any differences will be highlighted in a 'diff' image for review.  
 
 To use this feature:
-1. Add the location of your recording directory to a `screenshots.yaml`
+1. Add a recording directory to `screenshots.yaml`
     ```yaml
     recording: /tmp/screenshots_record
     ```
-1. Run a recording to capture your screenshots:
+1. Run a recording to capture expected screenshots:
     ```
     screenshots -m recording
     ```
@@ -257,7 +266,7 @@ To use this feature:
 To generate screenshots for local use, such as generating reports of changes to UI over time, etc... use 'archive' mode. 
 
 To enable this mode:
-1. Add the location of your archive directory to screenshots.yaml:
+1. Add an archive directory to screenshots.yaml:
     ```yaml
     archive: /tmp/screenshots_archive
     ```
@@ -267,7 +276,7 @@ To enable this mode:
     ````
 
 # Integration with Fastlane
-Since _Screenshots_ is intended to be used with Fastlane, after _Screenshots_ completes, the images can be found in your project at:
+Since _Screenshots_ is intended to be used with Fastlane, after _Screenshots_ completes, the images can be found in the project at:
 ````
 android/fastlane/metadata/android
 ios/fastlane/screenshots
@@ -282,40 +291,32 @@ Tip: One way to use _Screenshots_ with Fastlane is to call _Screenshots_ before 
 ## Fastlane FrameIt
 iOS images generated by _Screenshots_ can also be further processed using FrameIt's [text and background](https://docs.fastlane.tools/actions/frameit/#text-and-background) feature.
 
-# Changing devices
+# Adding a device
 
-To change the devices to run your tests on, just change the list of devices in screenshots.yaml.
-
-Make sure each device you select has a supported screen and a
-corresponding attached device or installed emulator/simulator. To bypass
-the supported screen requirement use `frame: false` for each related device in your
-screenshots.yaml.
-
-For each selected device:
 1. Confirm device is present in [screens.yaml](https://github.com/mmcc007/screenshots/blob/master/lib/resources/screens.yaml).  
 2. Add device to the list of devices in screenshots.yaml.  
 3. Confirm a real device is attached, or install an emulator/simulator for device.   
 
-If your device is not found in screens.yaml but matches a screen size in screens.yaml, please create an issue or PR to add the device to screens.yaml.
+If screen is not available, disable framing by setting `frame: false` for the device.
 
 ## Config validation
-_Screenshots_ will check your configuration before running for any errors and provide a guide on how to resolve.
+_Screenshots_ will check configuration before running for errors and provide a guide on how to resolve.
 
-# Adding new screens
+# Adding a screen
 
-If your device does not have a screen in screens.yaml please create an issue to request a new screen.
+If device does not have a screen in screens.yaml please create an issue to request a new screen.
 
-If you want to submit a new screen please see related [README](https://github.com/mmcc007/screenshots/blob/master/test/resources/README.md).
+To submit a new screen please see related [README](https://github.com/mmcc007/screenshots/blob/master/test/resources/README.md).
 
 # Upgrading
 To upgrade, simply re-issue the install command
 ````bash
 $ pub global activate screenshots
 ````
-Note: the _Screenshots_ version should be the same for both the command line and in your `pubspec.yaml`.   
+Note: the _Screenshots_ version should be the same for both the command line and in the `pubspec.yaml`.   
 1. If upgrading the command line version of _Screenshots_, also upgrade
- the version of _Screenshots_ in your pubspec.yaml.    
-2. If upgrading the version of _Screenshots_ in your pubspec.yaml, also upgrade the command line version.
+ the version of _Screenshots_ in the pubspec.yaml.    
+2. If upgrading the version of _Screenshots_ in pubspec.yaml, also upgrade the command line version.
 
 To check the version of _Screenshots_ currently installed:
 ```
@@ -332,8 +333,8 @@ https://github.com/mmcc007/screenshots/releases/
 To view a similar run on windows see:  
 https://ci.appveyor.com/project/mmcc007/screenshots
 
-* Running _Screenshots_ in the cloud is  useful for automating the generation of your screenshots in a CI/CD environment.  
-* Running _Screenshots_ on macOS in the cloud can be used to generate your screenshots when developing on Linux and/or Windows (if not using locally attached iOS devices).
+* Running _Screenshots_ in the cloud is  useful for automating the generation of screenshots in a CI/CD environment.  
+* Running _Screenshots_ on macOS in the cloud can be used to generate screenshots when developing on Linux and/or Windows.
 
 # Related projects
 To run integration tests on real devices in cloud:  
@@ -345,5 +346,3 @@ https://github.com/mmcc007/fledge
 # Issues and Pull Requests
 [Issues](https://github.com/mmcc007/screenshots/issues) and 
 [pull requests](https://github.com/mmcc007/screenshots/pulls) are welcome.
-
-Your feedback is welcome and is used to guide where development effort is focused. So feel free to create as many issues and pull requests as you want. You should expect a timely and considered response.

--- a/example/screenshots.yaml
+++ b/example/screenshots.yaml
@@ -20,7 +20,9 @@ devices:
       orientation: LandscapeRight
   android:
     Nexus 6P:
-      orientation: LandscapeRight
+      orientation:
+        - LandscapeRight
+        - Portrait
 
 # Frame screenshots
 frame: true

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -14,6 +14,7 @@ const kEnvConfigPath = 'SCREENSHOTS_YAML';
 
 /// Config info used to manage screenshots for android and ios.
 // Note: should not have context dependencies as is also used in driver.
+// todo: yaml validation
 class Config {
   Config({this.configPath = kConfigFileName, String configStr}) {
     if (configStr != null) {
@@ -162,7 +163,7 @@ class Config {
         for (final _orientation in Orientation.values) {
           print('  ${utils.getStringFromEnum(_orientation)}');
         }
-        io.exit(1);
+        io.exit(1); // todo: add tool exception and throw
       }
       return utils.getEnumFromString(Orientation.values, orientation);
     }
@@ -206,8 +207,6 @@ class ConfigDevice {
   final DeviceType deviceType;
   final bool isFramed;
   final List<Orientation> orientations;
-
-//  final List<String> orientationStrs; // for validation
   final bool isBuild;
 
   ConfigDevice(

--- a/lib/src/daemon_client.dart
+++ b/lib/src/daemon_client.dart
@@ -295,7 +295,7 @@ class DaemonDevice extends BaseDevice {
   }
 }
 
-DaemonEmulator loadDaemonEmulator(emulator) {
+DaemonEmulator loadDaemonEmulator(Map<String, dynamic> emulator) {
   return DaemonEmulator(
     emulator['id'],
     emulator['name'],
@@ -304,7 +304,7 @@ DaemonEmulator loadDaemonEmulator(emulator) {
   );
 }
 
-DaemonDevice loadDaemonDevice(device) {
+DaemonDevice loadDaemonDevice(Map<String, dynamic> device) {
   return DaemonDevice(
       device['id'],
       device['name'],

--- a/lib/src/image_processor.dart
+++ b/lib/src/image_processor.dart
@@ -95,7 +95,8 @@ class ImageProcessor {
           : null;
       // prefix screenshots with name of device before moving
       // (useful for uploading to apple via fastlane)
-      await utils.prefixFilesInDir(screenshotsDir, '$deviceName-');
+      await utils.prefixFilesInDir(screenshotsDir,
+          '$deviceName-${utils.getStringFromEnum(orientation)}-');
 
       printStatus('Moving screenshots to $dstDir');
       utils.moveFiles(screenshotsDir, dstDir);

--- a/lib/src/image_processor.dart
+++ b/lib/src/image_processor.dart
@@ -1,18 +1,18 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 import 'package:screenshots/src/config.dart';
 import 'package:screenshots/src/image_magick.dart';
+import 'package:screenshots/src/orientation.dart';
 import 'package:tool_base/tool_base.dart' hide Config;
 
 import 'archive.dart';
-import 'screens.dart';
 import 'fastlane.dart' as fastlane;
-import 'resources.dart' as resources;
-import 'utils.dart' as utils;
-import 'package:path/path.dart' as p;
-
 import 'globals.dart';
+import 'resources.dart' as resources;
+import 'screens.dart';
+import 'utils.dart' as utils;
 
 class ImageProcessor {
   static const _kDefaultIosBackground = 'xc:white';
@@ -23,6 +23,7 @@ class ImageProcessor {
 
   final Screens _screens;
   final Config _config;
+
   ImageProcessor(Screens screens, Config config)
       : _screens = screens,
         _config = config;
@@ -37,8 +38,14 @@ class ImageProcessor {
   /// If 'frame' in config file is true, screenshots are placed within image of device.
   ///
   /// After processing, screenshots are handed off for upload via fastlane.
-  Future<bool> process(DeviceType deviceType, String deviceName, String locale,
-      RunMode runMode, Archive archive) async {
+  Future<bool> process(
+    DeviceType deviceType,
+    String deviceName,
+    String locale,
+    Orientation orientation,
+    RunMode runMode,
+    Archive archive,
+  ) async {
     final Map screenProps = _screens.getScreen(deviceName);
     final screenshotsDir = '${_config.stagingDir}/$kTestScreenshotsDir';
     final screenshotPaths = fs.directory(screenshotsDir).listSync();
@@ -46,7 +53,7 @@ class ImageProcessor {
       printStatus('Warning: \'$deviceName\' images will not be processed');
     } else {
       // add frame if required
-      if (_config.isFrameRequired(deviceName)) {
+      if (_config.isFrameRequired(deviceName, orientation)) {
         final Map screenResources = screenProps['resources'];
         printStatus('Processing screenshots from test...');
 

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -357,6 +357,14 @@ class Screenshots {
                 deviceId,
               );
             }
+          } else {
+            await runProcessTests(
+              configDeviceName,
+              locale,
+              null,
+              deviceType,
+              deviceId,
+            );
           }
         }
         // if an emulator was started, revert locale if necessary and shut it down

--- a/lib/src/validate.dart
+++ b/lib/src/validate.dart
@@ -4,7 +4,6 @@ import 'package:tool_base/tool_base.dart' hide Config;
 
 import 'config.dart';
 import 'globals.dart';
-import 'orientation.dart';
 import 'screens.dart';
 import 'utils.dart' as utils;
 
@@ -30,7 +29,7 @@ Future<bool> isValidConfig(
   if (config.isRunTypeActive(DeviceType.android)) {
     final androidDevices = utils.getAndroidDevices(allDevices);
     for (ConfigDevice configDevice in config.androidDevices) {
-      if (config.isFrameRequired(configDevice.name)) {
+      if (config.isFrameRequired(configDevice.name, null)) {
         // check screen available for this device
         if (!_isScreenAvailable(screens, configDevice.name, configPath)) {
           isValid = false;
@@ -58,7 +57,7 @@ Future<bool> isValidConfig(
       final iosDevices = utils.getIosDaemonDevices(allDevices);
       final Map simulators = utils.getIosSimulators();
       for (ConfigDevice configDevice in config.iosDevices) {
-        if (config.isFrameRequired(configDevice.name)) {
+        if (config.isFrameRequired(configDevice.name, null)) {
           // check screen available for this device
           if (!_isScreenAvailable(screens, configDevice.name, configPath)) {
             isValid = false;
@@ -91,16 +90,6 @@ Future<bool> isValidConfig(
   for (final devName in deviceNames) {
     final configDevice = config.getDevice(devName);
     if (configDevice != null) {
-      if (configDevice.orientationStr != null &&
-          !isValidOrientation(configDevice.orientationStr)) {
-        printError(
-            'Invalid value for \'orientation\' for device \'$devName\': ${configDevice.orientationStr}');
-        printStatus('Valid values:');
-        for (final orientation in Orientation.values) {
-          printStatus('  ${utils.getStringFromEnum(orientation)}');
-        }
-        isValid = false;
-      }
       final frame = configDevice.isFramed;
       if (frame != null && !isValidFrame(frame)) {
         printError(
@@ -265,13 +254,6 @@ void _printSimulators() {
           ? -1
           : thisSim.compareTo(otherSim));
   simulatorNames.forEach((simulatorName) => printStatus('    $simulatorName'));
-}
-
-bool isValidOrientation(String orientation) {
-  return Orientation.values.firstWhere(
-          (o) => utils.getStringFromEnum(o) == orientation,
-          orElse: () => null) !=
-      null;
 }
 
 bool isValidFrame(dynamic frame) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,5 +34,7 @@ dev_dependencies:
   tool_base_test:
     git: https://github.com/mmcc007/tool_base_test.git
 #    path: ../tool_base_test
+  collection: any
+
 executables:
   screenshots: main

--- a/test/daemon_test.dart
+++ b/test/daemon_test.dart
@@ -126,17 +126,17 @@ main() {
       expect(model, expectedModel);
     });
 
-    test('get ios model from device id', () {
-      final deviceId = '3b3455019e329e007e67239d9b897148244b5053';
-      final devices = getIosDevices();
+//    test('get ios model from device id', () {
+//      final deviceId = '3b3455019e329e007e67239d9b897148244b5053';
+//      final devices = getIosDevices();
 //      print('devices=$devices');
-
-      final device = devices.firstWhere((device) => device['id'] == deviceId,
-          orElse: () => null);
+//
+//      final device = devices.firstWhere((device) => device['id'] == deviceId,
+//          orElse: () => null);
 //      device == null
 //          ? print('device not attached')
 //          : print('model=${device['model']}');
-    }, skip: utils.isCI());
+//    }, skip: utils.isCI());
 
     test('run test on real device', () async {
       final deviceName = 'iPhone 5c';
@@ -169,14 +169,14 @@ main() {
       await shutdownAndroidEmulator(daemonClient, deviceId);
     }, skip: utils.isCI());
 
-    test('join devices', () {
-      final configPath = 'test/screenshots_test.yaml';
-      final config = Config(configPath: configPath);
-      final androidInfo = config.androidDevices;
+//    test('join devices', () {
+//      final configPath = 'test/screenshots_test.yaml';
+//      final config = Config(configPath: configPath);
+//      final androidInfo = config.androidDevices;
 //      print('androidInfo=$androidInfo');
-      List deviceNames = config.deviceNames;
+//      List deviceNames = config.deviceNames;
 //      print('deviceNames=$deviceNames');
-    });
+//    });
 
     test('run test on matching devices or emulators', () async {
       final configPath = 'test/screenshots_test.yaml';

--- a/test/image_processor_test.dart
+++ b/test/image_processor_test.dart
@@ -117,7 +117,7 @@ main() {
 
       final imageProcessor = ImageProcessor(screens, config);
       final result = await imageProcessor.process(
-          DeviceType.android, deviceName, locale, RunMode.normal, null);
+          DeviceType.android, deviceName, locale, null, RunMode.normal, null);
       expect(result, isTrue);
       fakeProcessManager.verifyCalls();
     }, overrides: <Type, Generator>{

--- a/test/run_test.dart
+++ b/test/run_test.dart
@@ -590,6 +590,7 @@ main() {
       final result = await screenshots.runProcessTests(
         deviceName,
         'locale',
+        null,
         getDeviceType(screenshots.config, deviceName),
         deviceId,
       );

--- a/test/screenshots_test.dart
+++ b/test/screenshots_test.dart
@@ -791,10 +791,10 @@ void main() {
 //        print('deviceInfo=$deviceInfo');
           if (deviceInfo != null) {
             if (deviceInfo.name == deviceName) {
-              expect(deviceInfo.orientation,
+              expect(deviceInfo.orientations,
                   utils.getEnumFromString(Orientation.values, orientation));
-              expect(validate.isValidOrientation(orientation), isTrue);
-              expect(validate.isValidOrientation('bad orientation'), isFalse);
+//              expect(validate.isValidOrientation(orientation), isTrue);
+//              expect(validate.isValidOrientation('bad orientation'), isFalse);
             }
             expect(deviceInfo.isFramed, frame);
             expect(validate.isValidFrame(frame), isTrue);

--- a/test/screenshots_test.dart
+++ b/test/screenshots_test.dart
@@ -20,7 +20,6 @@ import 'package:screenshots/src/utils.dart';
 import 'package:screenshots/src/validate.dart' as validate;
 import 'package:test/test.dart';
 import 'package:path/path.dart' as p;
-import 'package:tool_mobile/tool_mobile.dart';
 
 import 'src/common.dart';
 
@@ -689,12 +688,12 @@ void main() {
       }, skip: utils.isCI());
     });
 
-    group('adb path', () {
-      test('find adb path', () async {
-        final _adbPath = getAdbPath(androidSdk);
-//      print('adbPath=$_adbPath');
-      }, skip: utils.isCI());
-    });
+//    group('adb path', () {
+//      test('find adb path', () async {
+//        final _adbPath = getAdbPath(androidSdk);
+////      print('adbPath=$_adbPath');
+//      }, skip: utils.isCI());
+//    });
 
     group('manage device orientation', () {
       test('find ios simulator orientation', () async {
@@ -803,12 +802,12 @@ void main() {
         }
       });
 
-      test('valid values for params', () {
-//      print(Orientation.values);
-        for (final orientation in Orientation.values) {
-//        print('${utils.getStringFromEnum(orientation)}');
-        }
-      });
+//      test('valid values for params', () {
+////      print(Orientation.values);
+//        for (final orientation in Orientation.values) {
+////        print('${utils.getStringFromEnum(orientation)}');
+//        }
+//      });
     });
 
     group('flavors', () {

--- a/test/screenshots_test.dart
+++ b/test/screenshots_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:process/process.dart';
 import 'package:screenshots/src/config.dart';
 import 'package:screenshots/src/context_runner.dart';
@@ -11,15 +12,14 @@ import 'package:screenshots/src/image_magick.dart';
 import 'package:screenshots/src/image_processor.dart';
 import 'package:screenshots/src/orientation.dart' as orient;
 import 'package:screenshots/src/orientation.dart';
-import 'package:screenshots/src/run.dart';
-import 'package:screenshots/src/screens.dart';
 import 'package:screenshots/src/resources.dart' as resources;
+import 'package:screenshots/src/run.dart';
 import 'package:screenshots/src/run.dart' as run;
+import 'package:screenshots/src/screens.dart';
 import 'package:screenshots/src/utils.dart' as utils;
 import 'package:screenshots/src/utils.dart';
 import 'package:screenshots/src/validate.dart' as validate;
 import 'package:test/test.dart';
-import 'package:path/path.dart' as p;
 
 import 'src/common.dart';
 
@@ -790,8 +790,8 @@ void main() {
 //        print('deviceInfo=$deviceInfo');
           if (deviceInfo != null) {
             if (deviceInfo.name == deviceName) {
-              expect(deviceInfo.orientations,
-                  utils.getEnumFromString(Orientation.values, orientation));
+              expect(utils.getEnumFromString(Orientation.values, orientation),
+                  deviceInfo.orientations[0]);
 //              expect(validate.isValidOrientation(orientation), isTrue);
 //              expect(validate.isValidOrientation('bad orientation'), isFalse);
             }

--- a/test/screenshots_yaml_test.dart
+++ b/test/screenshots_yaml_test.dart
@@ -119,12 +119,12 @@ void main() {
   test('check if frame is needed', () {
     final config = Config(configStr: screenshotsYaml);
 
-    expect(config.isFrameRequired('iPhone X'), true);
-    expect(config.isFrameRequired('iPhone 7 Plus'), false);
-    expect(config.isFrameRequired('Nexus 5X'), true);
-    expect(config.isFrameRequired('iPhone 5c'), false);
+    expect(config.isFrameRequired('iPhone X', null), true);
+    expect(config.isFrameRequired('iPhone 7 Plus', null), false);
+    expect(config.isFrameRequired('Nexus 5X', null), true);
+    expect(config.isFrameRequired('iPhone 5c', null), false);
     final unknownDevice = 'unknown';
-    expect(() => config.isFrameRequired('unknown'),
+    expect(() => config.isFrameRequired('unknown', null),
         throwsA('Error: device \'$unknownDevice\' not found'));
   });
 }

--- a/test/validate_test.dart
+++ b/test/validate_test.dart
@@ -244,6 +244,8 @@ main() {
     }, skip: false, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
       Logger: () => BufferLogger(),
+      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
+        ..operatingSystem = 'macos',
     });
 
     testUsingContext('show guide', () async {

--- a/test/validate_test.dart
+++ b/test/validate_test.dart
@@ -237,15 +237,15 @@ main() {
       expect(logger.errorText, contains('File \'example/test_driver/main.dartx\' not found.'));
       expect(logger.errorText, contains('Invalid config: \'example/test_driver/main.dartx\' in screenshots.yaml'));
       expect(logger.errorText, contains('Screen not available for device \'Bad android phone\' in screenshots.yaml.'));
-      expect(logger.errorText, contains('Screen not available for device \'Bad ios phone\' in screenshots.yaml.'));
+//      expect(logger.errorText, contains('Screen not available for device \'Bad ios phone\' in screenshots.yaml.'));
       expect(logger.errorText, contains('No device attached or emulator installed for device \'Bad android phone\' in screenshots.yaml.'));
       expect(logger.errorText, contains('No device attached or emulator installed for device \'Unknown android phone\' in screenshots.yaml.'));
-      expect(logger.errorText, contains('No device attached or simulator installed for device \'Bad ios phone\' in screenshots.yaml.'));
+//      expect(logger.errorText, contains('No device attached or simulator installed for device \'Bad ios phone\' in screenshots.yaml.'));
     }, skip: false, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
       Logger: () => BufferLogger(),
       Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-        ..operatingSystem = 'macos',
+        ..operatingSystem = 'linux',
     });
 
     testUsingContext('show guide', () async {

--- a/test/validate_test.dart
+++ b/test/validate_test.dart
@@ -237,15 +237,16 @@ main() {
       expect(logger.errorText, contains('File \'example/test_driver/main.dartx\' not found.'));
       expect(logger.errorText, contains('Invalid config: \'example/test_driver/main.dartx\' in screenshots.yaml'));
       expect(logger.errorText, contains('Screen not available for device \'Bad android phone\' in screenshots.yaml.'));
-//      expect(logger.errorText, contains('Screen not available for device \'Bad ios phone\' in screenshots.yaml.'));
+      expect(logger.errorText, contains('Screen not available for device \'Bad ios phone\' in screenshots.yaml.'));
       expect(logger.errorText, contains('No device attached or emulator installed for device \'Bad android phone\' in screenshots.yaml.'));
       expect(logger.errorText, contains('No device attached or emulator installed for device \'Unknown android phone\' in screenshots.yaml.'));
-//      expect(logger.errorText, contains('No device attached or simulator installed for device \'Bad ios phone\' in screenshots.yaml.'));
+      expect(logger.errorText, contains('No device attached or simulator installed for device \'Bad ios phone\' in screenshots.yaml.'));
     }, skip: false, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
       Logger: () => BufferLogger(),
-      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-        ..operatingSystem = 'linux',
+//      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
+//        ..operatingSystem = 'linux',
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('show guide', () async {


### PR DESCRIPTION
Run test on a device in multiple orientations in a single run. This avoids the need to have different runs for each orientation.
Fixes #162
