### PR TITLE
Use ADB to take screenshots of android devices

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,6 @@ android_integration_task:
     - adb shell getprop ro.build.version.release # '9' (emulator)
     - adb shell getprop ro.build.version.sdk # '28' (emulator))
     - adb shell getprop
-    - sleep 5 # Wait 5 seconds for android adb services like 'settings' to come up
 #  logcat_background_script: adb logcat -e flutter\|Observatory *:I
   logcat_background_script: adb logcat -e flutter\|Observatory
   doctor_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,6 +135,7 @@ android_integration_task:
     - adb shell getprop ro.build.version.release # '9' (emulator)
     - adb shell getprop ro.build.version.sdk # '28' (emulator))
     - adb shell getprop
+    - sleep 5 # Wait 5 seconds for android adb services like 'settings' to come up
 #  logcat_background_script: adb logcat -e flutter\|Observatory *:I
   logcat_background_script: adb logcat -e flutter\|Observatory
   doctor_script:

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ example/android/fastlane
 
 # code coverage
 coverage/
+example/ios/Flutter/flutter_export_environment.sh
+example/ios/Flutter/Flutter.podspec

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Dart",
+            "program": "../bin/main.dart",
+            "args": ["-c", "screenshots.yaml"],
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            
+        }
+    ]
+}

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Mon Dec 23 18:39:35 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/example/test_driver/main_test.dart
+++ b/example/test_driver/main_test.dart
@@ -28,27 +28,29 @@ void main() {
     });
 
     test('tap on the floating action button; verify counter', () async {
-      // Finds the floating action button (fab) to tap on
-      SerializableFinder fab =
-          find.byTooltip(localizations['counterIncrementButtonTooltip']);
+      // Use unsynchronized FlutterDriver.
+      // This prevents timeouts when there is an infinite amount of pending frames.
+      await driver.runUnsynchronized(() async {
+        // Finds the floating action button (fab) to tap on
+        SerializableFinder fab =
+            find.byTooltip(localizations['counterIncrementButtonTooltip']);
+                  // Wait for the floating action button to appear
+        await driver.waitFor(fab);
 
-      // Wait for the floating action button to appear
-      await driver.waitFor(fab);
+        // take screenshot before number is incremented
+        await screenshot(driver, config, '0');
 
-      // take screenshot before number is incremented
-      await screenshot(driver, config, '0');
+        // Tap on the fab
+        await driver.tap(fab);
 
-      // Tap on the fab
-      await driver.tap(fab);
+        // Wait for text to change to the desired value
+        await driver.waitFor(find.text('1'));
 
-      // Wait for text to change to the desired value
-      await driver.waitFor(find.text('1'));
-
-      // take screenshot after number is incremented
-      await screenshot(driver, config, '1');
-
+        // take screenshot after number is incremented
+        await screenshot(driver, config, '1');
+      });
       // increase timeout from 30 seconds for testing
       // on slow running emulators in cloud
-    }, timeout: Timeout(Duration(seconds: 120)));
+      }, timeout: Timeout(Duration(seconds: 120)));
   });
 }

--- a/lib/src/capture_screen.dart
+++ b/lib/src/capture_screen.dart
@@ -43,8 +43,12 @@ Future _takeScreenshotUsingAdb(File destination, String adbLocation, String devi
     utils.cmd([adbLocation, '-s', deviceId, 'shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1'], trace: false);
     utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'enter'], trace: false);
     utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'clock', '-e', 'hhmm', '1600'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'battery', '-e', 'plugged', 'false'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'battery', '-e', 'level', '100'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'network', '-e', 'wifi', 'show', '-e', 'level', '4'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'network', '-e', 'mobile', 'show', '-e', 'datatype', 'none', '-e', 'level', '4'], trace: false);
     utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'notifications', '-e', 'visible', 'false'], trace: false);
-    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1'], trace: false);
+    sleep(Duration(milliseconds: 500)); // Wait for statusbar animations to complete
 
     // Take Screenshot
     final screenshotResult = await Process.run(adbLocation, ['-s', deviceId, 'exec-out', 'screencap', '-p'], stdoutEncoding: null);

--- a/lib/src/capture_screen.dart
+++ b/lib/src/capture_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'config.dart';
 import 'globals.dart';
+import 'utils.dart' as utils;
 
 /// Called by integration test to capture images.
 Future screenshot(final driver, Config config, String name,
@@ -11,17 +12,54 @@ Future screenshot(final driver, Config config, String name,
     bool waitUntilNoTransientCallbacks = true}) async {
   if (config.isScreenShotsAvailable) {
     // todo: auto-naming scheme
-    if (waitUntilNoTransientCallbacks) {
-      await driver.waitUntilNoTransientCallbacks(timeout: timeout);
+    final testDir = '${config.stagingDir}/$kTestScreenshotsDir';
+    final fileLocationAdb = await File('$testDir/$name.adb.$kImageExtension');
+    final fileLocationDriver = await File('$testDir/$name.driver.$kImageExtension');
+
+    final env = await config.screenshotsEnv;   
+    if(env.containsKey('adb_path') && env.containsKey('adb_device_id') && env.containsKey('device_type') && env['device_type'] == 'android'){
+      try {
+        await _takeScreenshotUsingAdb(fileLocationAdb, env['adb_path'], env['adb_device_id']);
+      } catch (e) {
+        if(!silent) print('Warning: Failed to take screenshot $name using adb. Using FlutterDriver as fallback method.');
+        if(await fileLocationAdb.exists()) await fileLocationAdb.delete();
+        await _takeScreenshotUsingFlutterDriver(fileLocationDriver, driver, timeout, waitUntilNoTransientCallbacks);
+      }
+    }else{
+      await _takeScreenshotUsingFlutterDriver(fileLocationDriver, driver, timeout, waitUntilNoTransientCallbacks);
     }
 
-    final pixels = await driver.screenshot();
-    final testDir = '${config.stagingDir}/$kTestScreenshotsDir';
-    final file =
-        await File('$testDir/$name.$kImageExtension').create(recursive: true);
-    await file.writeAsBytes(pixels);
-    if (!silent) print('Screenshot $name created');
+    if (!silent) print('Screenshot $name created using ${await fileLocationAdb.exists() ? "adb" : "flutter driver"}');
   } else {
     if (!silent) print('Warning: screenshot $name not created');
   }
+}
+
+Future _takeScreenshotUsingAdb(File destination, String adbLocation, String deviceId) async {
+  try {
+    await destination.create(recursive: true);
+    
+    // Activate Demo Mode
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'enter'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'clock', '-e', 'hhmm', '1600'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'notifications', '-e', 'visible', 'false'], trace: false);
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1'], trace: false);
+
+    // Take Screenshot
+    final screenshotResult = await Process.run(adbLocation, ['-s', deviceId, 'exec-out', 'screencap', '-p'], stdoutEncoding: null);
+    await destination.writeAsBytes(screenshotResult.stdout); 
+  } finally {
+    // Deactivate Demo Mode
+    utils.cmd([adbLocation, '-s', deviceId, 'shell', 'am', 'broadcast', '-a', 'com.android.systemui.demo', '-e', 'command', 'exit'], trace: false);
+  }
+}
+
+Future _takeScreenshotUsingFlutterDriver(File destination, driver, Duration timeout, bool waitUntilNoTransientCallbacks) async {
+  await destination.create(recursive: true);
+  if (waitUntilNoTransientCallbacks) {
+    await driver.waitUntilNoTransientCallbacks(timeout: timeout);
+  }
+  final pixels = await driver.screenshot();
+  await destination.writeAsBytes(pixels);
 }

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -123,13 +123,15 @@ class Config {
   /// (called by screenshots)
   @visibleForTesting
   Future<void> storeEnv(Screens screens, String emulatorName, String locale,
-      DeviceType deviceType, Orientation orientation) async {
+      DeviceType deviceType, Orientation orientation, String adbPath, String adbDeviceId) async {
     // store env for later use by tests
     final screenProps = screens.getScreen(emulatorName);
     final screenSize = screenProps == null ? null : screenProps['size'];
     final currentEnv = {
       'screen_size': screenSize,
       'locale': locale,
+      'adb_path': adbPath,
+      'adb_device_id': adbDeviceId,
       'device_name': emulatorName,
       'device_type': utils.getStringFromEnum(deviceType),
       'orientation': utils.getStringFromEnum(orientation)

--- a/lib/src/image_processor.dart
+++ b/lib/src/image_processor.dart
@@ -66,14 +66,16 @@ class ImageProcessor {
           printStatus('Warning: no screenshots found in $screenshotsDir');
         }
         for (final screenshotPath in screenshotPaths) {
-          // add status bar for each screenshot
-          await overlay(
-              _config.stagingDir, screenResources, screenshotPath.path);
-
-          if (deviceType == DeviceType.android) {
-            // add nav bar for each screenshot
-            await append(
+          if(p.basenameWithoutExtension(screenshotPath.path).endsWith('.driver')){
+            // add status bar for each screenshot
+            await overlay(
                 _config.stagingDir, screenResources, screenshotPath.path);
+
+            if (deviceType == DeviceType.android) {
+              // add nav bar for each screenshot
+              await append(
+                  _config.stagingDir, screenResources, screenshotPath.path);
+            }
           }
 
           await frame(_config.stagingDir, screenProps, screenshotPath.path,

--- a/lib/src/image_processor.dart
+++ b/lib/src/image_processor.dart
@@ -66,7 +66,7 @@ class ImageProcessor {
           printStatus('Warning: no screenshots found in $screenshotsDir');
         }
         for (final screenshotPath in screenshotPaths) {
-          if(p.basenameWithoutExtension(screenshotPath.path).endsWith('.driver')){
+          if(!p.basenameWithoutExtension(screenshotPath.path).endsWith('.adb')){
             // add status bar for each screenshot
             await overlay(
                 _config.stagingDir, screenResources, screenshotPath.path);

--- a/lib/src/orientation.dart
+++ b/lib/src/orientation.dart
@@ -39,7 +39,7 @@ void changeDeviceOrientation(DeviceType deviceType, Orientation orientation,
         'system',
         'user_rotation',
         androidOrientations[_orientation]
-      ]);
+      ], retry: true);
       break;
     case DeviceType.ios:
       // requires permission when run for first time

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -347,7 +347,13 @@ class Screenshots {
               // store env for later use by tests
               // ignore: invalid_use_of_visible_for_testing_member
               await config.storeEnv(
-                  screens, configDeviceName, locale, deviceType, orientation);
+                  screens,
+                  configDeviceName,
+                  locale,
+                  deviceType,
+                  orientation,
+                  getAdbPath(androidSdk),
+                  deviceId);
 
               // run tests and process images
               await runProcessTests(
@@ -359,6 +365,14 @@ class Screenshots {
               );
             }
           } else {
+            await config.storeEnv(
+              screens,
+              configDeviceName,
+              locale,
+              deviceType,
+              null,
+              getAdbPath(androidSdk),
+              deviceId);
             await runProcessTests(
               configDeviceName,
               locale,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -425,12 +425,13 @@ String cmd(List<String> cmd,
       final result = processManager.runSync(cmd, workingDirectory: workingDirectory, runInShell: true);
       if(trace) _traceCommand(cmd, workingDirectory: workingDirectory);
       if (result.exitCode != 0) {
-        error = StdoutException(result.stdout, OSError(result.stderr, result.exitCode));
-        throw error;
+        throw StdoutException(result.stdout, OSError(result.stderr, result.exitCode));
       }
       // return stdout
       return result.stdout;
     } on StdoutException catch (e) {
+      error = e;
+      if(!retry) rethrow;
       sleep(Duration(seconds: 5));
     }
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -131,7 +131,7 @@ Future prefixFilesInDir(String dirPath, String prefix) async {
   await for (final file
       in fs.directory(dirPath).list(recursive: false, followLinks: false)) {
     await file
-        .rename(p.dirname(file.path) + '/' + prefix + p.basename(file.path));
+        .rename(p.dirname(file.path) + '/' + prefix + p.basenameWithoutExtension(p.basenameWithoutExtension(file.path)) + '.$kImageExtension');
   }
 }
 
@@ -416,10 +416,10 @@ Future<bool> isEmulatorPath() async {
 
 /// Run command and return stdout as [string].
 String cmd(List<String> cmd,
-    {String workingDirectory, bool silent = true}) {
+    {String workingDirectory, bool silent = true, bool trace = true}) {
   final result = processManager.runSync(cmd,
       workingDirectory: workingDirectory, runInShell: true);
-  _traceCommand(cmd, workingDirectory: workingDirectory);
+  if(trace) _traceCommand(cmd, workingDirectory: workingDirectory);
   if (!silent) printStatus(result.stdout);
   if (result.exitCode != 0) {
     if (silent) printError(result.stdout);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,22 +5,20 @@ homepage: https://github.com/mmcc007/screenshots
 author: Maurice McCabe <mmcc007@gmail.com>
 
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
   args: ^1.5.1
   yaml: ^2.1.15
   resource: ^2.1.5
   path: ^1.6.2
-  file: ^5.0.7
+  file: ^6.0.0-nullsafety.2
   archive: ^2.0.9
-  platform: ^2.2.0
-  process: ^3.0.9
+  platform: ^3.0.0-nullsafety.2
+  process: ^4.0.0-nullsafety.2
   meta: ^1.1.6
   intl: ">=0.15.0 <1.0.0"
-  tool_mobile: ^1.9.5
-#  tool_mobile:
-#    path: ../tool_mobile
+  tool_mobile: ^2.0.0
 
 dev_dependencies:
   test: ^1.5.1+1
@@ -28,11 +26,8 @@ dev_dependencies:
   mockito: ^4.1.0
   pedantic: ^1.8.0+1
   quiver: '>=2.0.0 <3.0.0'
-  fake_process_manager: ^0.1.0
+  fake_process_manager: ^0.2.0
 #    path: ../fake_process_manager
-  tool_base_test:
-    git: https://github.com/mmcc007/tool_base_test.git
-#    path: ../tool_base_test
   collection: any
 
 executables:

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -188,6 +188,8 @@ main() {
       final env = {
         'screen_size': '1440x2560',
         'locale': 'en_US',
+        'adb_path': 'adb',
+        'adb_device_id': 'emulator-000',
         'device_name': 'Nexus 6P',
         'device_type': 'android',
         'orientation': orientation
@@ -199,7 +201,9 @@ main() {
           env['device_name'],
           env['locale'],
           getEnumFromString(DeviceType.values, env['device_type']),
-          getEnumFromString(Orientation.values, orientation));
+          getEnumFromString(Orientation.values, orientation),
+          env['adb_path'], 
+          env['adb_device_id']);
 
       // called by test
       // simulate no screenshots available

--- a/test/image_magick_test.dart
+++ b/test/image_magick_test.dart
@@ -86,8 +86,7 @@ main() {
       fakeProcessManager.verifyCalls();
     }, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
-      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-        ..operatingSystem = 'macos',
+      Platform: () => FakePlatform(operatingSystem: 'macos'),
     });
 
     testUsingContext('is installed on windows', () async {
@@ -97,8 +96,7 @@ main() {
       fakeProcessManager.verifyCalls();
     }, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
-      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-        ..operatingSystem = 'windows',
+      Platform: () => FakePlatform(operatingSystem: 'windows'),
     });
 
     testUsingContext('is not installed on windows', () async {
@@ -110,8 +108,7 @@ main() {
       fakeProcessManager.verifyCalls();
     }, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
-      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-        ..operatingSystem = 'windows',
+      Platform: () => FakePlatform(operatingSystem: 'windows'),
     });
   });
 

--- a/test/run_test.dart
+++ b/test/run_test.dart
@@ -10,8 +10,9 @@ import 'package:screenshots/src/run.dart';
 import 'package:screenshots/src/screens.dart';
 import 'package:test/test.dart';
 import 'package:tool_base/tool_base.dart';
-import 'package:tool_base_test/tool_base_test.dart';
 
+import 'src/common_tools.dart';
+import 'src/context.dart';
 import 'src/mocks.dart';
 
 main() {
@@ -50,9 +51,11 @@ main() {
   });
 
   FakeProcessManager fakeProcessManager;
+  LocalPlatform localPlatform;
   MockDaemonClient mockDaemonClient;
 
   setUp(() async {
+    localPlatform = LocalPlatform();
     fakeProcessManager = FakeProcessManager(stdinResults: _captureStdin);
     mockDaemonClient = MockDaemonClient();
     when(mockDaemonClient.emulators)
@@ -449,13 +452,14 @@ main() {
       }, skip: false, overrides: <Type, Generator>{
         DaemonClient: () => mockDaemonClient,
         ProcessManager: () => fakeProcessManager,
-        Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-          ..environment = {
-//            'CI': 'false',
-//            'HOME': LocalPlatform().environment['HOME']
-            'HOME': memoryFileSystem.currentDirectory.path
-          }
-          ..operatingSystem = 'macos',
+        Platform: () => FakePlatform(
+              operatingSystem: 'macos',
+              environment: {
+//                'CI': 'false',
+//                'HOME': LocalPlatform().environment['HOME']
+                'HOME': memoryFileSystem.currentDirectory.path
+              },
+            ),
         Logger: () => BufferLogger(),
         FileSystem: () => memoryFileSystem,
       });
@@ -534,8 +538,9 @@ main() {
     }, skip: false, overrides: <Type, Generator>{
       DaemonClient: () => mockDaemonClient,
       ProcessManager: () => fakeProcessManager,
-      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-        ..environment = {'CI': 'true'},
+      Platform: () => FakePlatform(
+          operatingSystem: localPlatform.operatingSystem,
+          environment: {'CI': 'true'}),
       Logger: () => BufferLogger(),
     });
   });

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -6,10 +6,9 @@ import 'package:screenshots/src/daemon_client.dart';
 import 'package:screenshots/src/utils.dart';
 import 'package:test/test.dart';
 import 'package:tool_base/tool_base.dart';
-import 'package:tool_base_test/tool_base_test.dart';
 import 'package:tool_mobile/tool_mobile.dart';
 
-import 'src/common.dart';
+import 'src/context.dart';
 
 class FakeAndroidSDK extends Fake implements AndroidSdk {
   @override
@@ -63,10 +62,8 @@ main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => mockFileSystem,
         ProcessManager: () => fakeProcessManager,
-        Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-          ..environment = {
-            'HOME': ''
-          },    });
+        Platform: () => FakePlatform(environment: {'HOME': ''})
+      });
     });
 
     group('not in context', () {

--- a/test/validate_test.dart
+++ b/test/validate_test.dart
@@ -12,13 +12,15 @@ import 'src/context.dart';
 main() {
   group('validate', () {
     FakeProcessManager fakeProcessManager;
-    FakePlatform fakePlatform;
+    FakePlatform macos;
 
     setUp(() {
       fakeProcessManager = FakeProcessManager();
-      fakePlatform = FakePlatform.fromPlatform(const LocalPlatform())
-        ..operatingSystem = 'linux'
-        ..environment['CI'] = 'false';
+      macos = FakePlatform(
+        stdoutSupportsAnsi: false,
+        operatingSystem: 'macos',
+        environment: {'CI': 'false'},
+        );
     });
 
     final callListIosDevices = Call(
@@ -51,7 +53,6 @@ main() {
             ''));
 
     testUsingContext('pass on iOS with \'availability\'', () async {
-      fakePlatform.operatingSystem = 'macos';
       final configStr = '''
           tests:
             - example/test_driver/main.dart
@@ -78,7 +79,7 @@ main() {
     }, skip: false, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
 //      Logger: () => VerboseLogger(StdoutLogger()),
-      Platform: () => fakePlatform
+      Platform: () => macos
     });
 
     testUsingContext('pass on iOS with \'isAvailable\'', () async {
@@ -135,8 +136,7 @@ main() {
     }, skip: false, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
 //      Logger: () => VerboseLogger(StdoutLogger()),
-      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())
-        ..operatingSystem = 'macos',
+      Platform: () => macos,
     });
 
     testUsingContext('getIosSimulators', () async {
@@ -151,7 +151,6 @@ main() {
     });
 
     testUsingContext('fail', () async {
-      fakePlatform.operatingSystem = 'macos';
       final BufferLogger logger = context.get<Logger>();
       final configStr = '''
           tests:
@@ -231,12 +230,11 @@ main() {
 //      expect(logger.errorText, isNot(contains('No device attached or simulator installed for device \'Bad ios phone\' in screenshots.yaml.')));
     }, skip: false, overrides: <Type, Generator>{
       Logger: () => BufferLogger(),
-      Platform: () => fakePlatform,
+      Platform: () => macos,
       ProcessManager: () => fakeProcessManager,
     });
 
     testUsingContext('show device guide', () async {
-      fakePlatform.operatingSystem = 'macos';
       final BufferLogger logger = context.get<Logger>();
       final screens = Screens();
       await screens.init();
@@ -298,7 +296,7 @@ main() {
       fakeProcessManager.verifyCalls();
     }, skip: false, overrides: <Type, Generator>{
       Logger: () => BufferLogger(),
-      Platform: () => fakePlatform,
+      Platform: () => macos,
       ProcessManager: () => fakeProcessManager,
     });
   });


### PR DESCRIPTION
This PR implements ADB screenshots for android devices as discussed in https://github.com/mmcc007/screenshots/issues/175

Nexus 6P Before | Nexus 6P After
------------ | -------------
<img alt="image" src="https://user-images.githubusercontent.com/9327096/74103475-8047ac80-4b4c-11ea-9565-103504f7a40a.png"> | <img alt="image" src="https://user-images.githubusercontent.com/9327096/74103940-8fc8f480-4b50-11ea-85b5-9c08982511f9.png">



**Main Changes:**
- Added `adb_path` & `adb_device_id` to `config.screenshotsEnv`
- [capture_screen.dart](https://github.com/mmcc007/screenshots/compare/master...r1sim:master#diff-2eecded90e98e313ff360c1291b11f8fR20) now checks if the new variables in `config.screenshotsEnv` are set and if the `device_type` is android. If that is the case it will attempt to take screenshots using adb. It will use FlutterDriver to take the screenshots if the adb method fails for whatever reason.
- The new screenshot method for android uses adb to take screenshots and [to setup the navbar](https://android.googlesource.com/platform/frameworks/base/+/master/packages/SystemUI/docs/demo_mode.md)
- The unprocessed screenshots now have the extension `.adb.png` or `.driver.png` so the image processor knows how to process them. (Add Navbar or not)
- I upgraded the SDK version of the example app to a more recent version.

This works well with my setup. If it works as well for everyone else we could maybe think about dropping FlutterDriver support for android devices. This would make it much easier to add new devices because we would no longer need to add a statusbar and navbar for every resolution. The only downside of this would be that demo mode requires android 6.0.