### PR TITLE
Add some obvious Android devices (Nexus 7 and Nexus 10) to screens.yaml

### DIFF
--- a/lib/resources/screens.yaml
+++ b/lib/resources/screens.yaml
@@ -156,7 +156,9 @@ android:
     destName: sevenInch
     devices:
       - default seven inch
+      - Nexus 7
   default tenInch:
     destName: tenInch
     devices:
       - default ten inch
+      - Nexus 10


### PR DESCRIPTION
I'm using these AVDs for my sevenInchScreenshots and tenInchScreenshots, so I needed to update screens.yaml to get the right behavior.